### PR TITLE
feat: add context menu to sidebar tabs

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -46,7 +46,10 @@
     "untitled": "Untitled",
     "create_tab": "New Tab",
     "from_clipboard": "Clipboard {timestamp}",
-    "from_drop": "Drop {timestamp}"
+    "from_drop": "Drop {timestamp}",
+    "rename_tab": "Rename",
+    "duplicate_tab": "Duplicate",
+    "delete_tab": "Delete"
   },
   "schema": {
     "editor_title": "JSON Schema Editor",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -46,7 +46,10 @@
     "untitled": "未命名",
     "create_tab": "新建标签页",
     "from_clipboard": "自剪贴板 {timestamp}",
-    "from_drop": "拖放 {timestamp}"
+    "from_drop": "拖放 {timestamp}",
+    "rename_tab": "重命名",
+    "duplicate_tab": "创建副本",
+    "delete_tab": "删除"
   },
   "schema": {
     "editor_title": "JSON Schema 编辑器",

--- a/src/components/LayoutSidebar.vue
+++ b/src/components/LayoutSidebar.vue
@@ -190,6 +190,13 @@ function handleTabRename(id: string, title: string) {
   workspaceStore.renameTab(id, title)
 }
 
+function handleTabDuplicate(id: string) {
+  const newTabId = workspaceStore.duplicateTab(id)
+  if (newTabId) {
+    workspaceStore.setActiveTab(newTabId)
+  }
+}
+
 function handleCreateTab() {
   if (!activeWorkspaceId.value)
     return
@@ -384,6 +391,7 @@ async function handleClearAllData() {
           @select="handleTabSelect"
           @delete="handleTabDelete"
           @rename="handleTabRename"
+          @duplicate="handleTabDuplicate"
           @reorder="handleTabReorder"
         />
         <div

--- a/src/components/TabList.vue
+++ b/src/components/TabList.vue
@@ -12,6 +12,7 @@ const emit = defineEmits<{
   select: [id: string]
   delete: [id: string]
   rename: [id: string, title: string]
+  duplicate: [id: string]
   reorder: [newOrder: string[]]
 }>()
 
@@ -29,6 +30,10 @@ function handleDelete(id: string) {
 
 function handleRename(id: string, title: string) {
   emit('rename', id, title)
+}
+
+function handleDuplicate(id: string) {
+  emit('duplicate', id)
 }
 
 function handleDragStart(e: DragEvent, tabId: string) {
@@ -116,6 +121,7 @@ function handleDrop(e: DragEvent, targetId: string) {
         @select="handleSelect"
         @delete="handleDelete"
         @rename="handleRename"
+        @duplicate="handleDuplicate"
       />
     </div>
   </div>

--- a/src/components/TabListItem.vue
+++ b/src/components/TabListItem.vue
@@ -1,8 +1,18 @@
 <script setup lang="ts">
 import type { Tab } from '@/db'
 import { nextTick, ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Button } from '@/components/ui/button'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { Input } from '@/components/ui/input'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   tab: Tab
@@ -13,6 +23,7 @@ const emit = defineEmits<{
   select: [id: string]
   delete: [id: string]
   rename: [id: string, title: string]
+  duplicate: [id: string]
 }>()
 
 const isEditing = ref(false)
@@ -55,44 +66,75 @@ function handleKeydown(e: KeyboardEvent) {
     isEditing.value = false
   }
 }
+
+function handleRename() {
+  startEditing()
+}
+
+function handleDuplicate() {
+  emit('duplicate', props.tab.id)
+}
+
+function handleContextDelete() {
+  emit('delete', props.tab.id)
+}
 </script>
 
 <template>
-  <div
-    class="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors"
-    :class="[
-      isActive
-        ? 'bg-accent text-accent-foreground'
-        : 'hover:bg-accent/50',
-    ]"
-    @click="handleSelect"
-  >
-    <div class="i-mingcute-file-line text-muted-foreground shrink-0" />
-    <Input
-      v-if="isEditing"
-      ref="inputRef"
-      v-model="editingTitle"
-      size="xs"
-      class="h-5 min-w-0 flex-1 px-1 py-0 text-sm"
-      @blur="finishEditing"
-      @keydown="handleKeydown"
-      @click.stop
-    />
-    <span
-      v-else
-      class="min-w-0 flex-1 truncate"
-      @dblclick.stop="startEditing"
-    >
-      {{ tab.title }}
-    </span>
-    <Button
-      v-if="!isEditing"
-      variant="ghost"
-      size="icon"
-      class="size-5 shrink-0 opacity-0 group-hover:opacity-100"
-      @click="handleDelete"
-    >
-      <div class="i-mingcute-close-line text-sm" />
-    </Button>
-  </div>
+  <ContextMenu>
+    <ContextMenuTrigger as-child>
+      <div
+        class="group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors"
+        :class="[
+          isActive
+            ? 'bg-accent text-accent-foreground'
+            : 'hover:bg-accent/50',
+        ]"
+        @click="handleSelect"
+      >
+        <div class="i-mingcute-file-line text-muted-foreground shrink-0" />
+        <Input
+          v-if="isEditing"
+          ref="inputRef"
+          v-model="editingTitle"
+          size="xs"
+          class="h-5 min-w-0 flex-1 px-1 py-0 text-sm"
+          @blur="finishEditing"
+          @keydown="handleKeydown"
+          @click.stop
+        />
+        <span
+          v-else
+          class="min-w-0 flex-1 truncate"
+          @dblclick.stop="startEditing"
+        >
+          {{ tab.title }}
+        </span>
+        <Button
+          v-if="!isEditing"
+          variant="ghost"
+          size="icon"
+          class="size-5 shrink-0 opacity-0 group-hover:opacity-100"
+          @click="handleDelete"
+        >
+          <div class="i-mingcute-close-line text-sm" />
+        </Button>
+      </div>
+    </ContextMenuTrigger>
+    <ContextMenuContent>
+      <ContextMenuItem @select="handleRename">
+        <div class="i-mingcute-edit-2-line mr-2" />
+        {{ t('tab.rename_tab') }}
+      </ContextMenuItem>
+      <ContextMenuItem @select="handleDuplicate">
+        <div class="i-mingcute-copy-2-line mr-2" />
+        {{ t('tab.duplicate_tab') }}
+      </ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem class="text-destructive focus:text-destructive" @select="handleContextDelete">
+        <div class="i-mingcute-delete-2-line mr-2" />
+        {{ t('tab.delete_tab') }}
+      </ContextMenuItem>
+    </ContextMenuContent>
+  </ContextMenu>
 </template>

--- a/src/components/ui/context-menu/ContextMenu.vue
+++ b/src/components/ui/context-menu/ContextMenu.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { ContextMenuRootEmits, ContextMenuRootProps } from 'reka-ui'
+import { ContextMenuRoot, useForwardPropsEmits } from 'reka-ui'
+
+const props = defineProps<ContextMenuRootProps>()
+const emits = defineEmits<ContextMenuRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <ContextMenuRoot v-bind="forwarded">
+    <slot />
+  </ContextMenuRoot>
+</template>

--- a/src/components/ui/context-menu/ContextMenuContent.vue
+++ b/src/components/ui/context-menu/ContextMenuContent.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { ContextMenuContentProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { ContextMenuContent, ContextMenuPortal, useForwardProps } from 'reka-ui'
+import { computed } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = withDefaults(
+  defineProps<ContextMenuContentProps & { class?: HTMLAttributes['class'] }>(),
+  {
+    alignOffset: 4,
+    sideOffset: 8,
+  },
+)
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <ContextMenuPortal>
+    <ContextMenuContent
+      v-bind="forwardedProps"
+      :class="
+        cn(
+          'z-50 min-w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          props.class,
+        )
+      "
+    >
+      <slot />
+    </ContextMenuContent>
+  </ContextMenuPortal>
+</template>

--- a/src/components/ui/context-menu/ContextMenuItem.vue
+++ b/src/components/ui/context-menu/ContextMenuItem.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { ContextMenuItemEmits, ContextMenuItemProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import {
+  ContextMenuItem,
+
+  useForwardPropsEmits,
+} from 'reka-ui'
+import { computed } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<ContextMenuItemProps & { class?: HTMLAttributes['class'], inset?: boolean }>()
+
+const emits = defineEmits<ContextMenuItemEmits>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <ContextMenuItem
+    v-bind="forwarded"
+    :class="cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      props.class,
+    )"
+  >
+    <slot />
+  </ContextMenuItem>
+</template>

--- a/src/components/ui/context-menu/ContextMenuSeparator.vue
+++ b/src/components/ui/context-menu/ContextMenuSeparator.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { ContextMenuSeparatorProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { ContextMenuSeparator, useForwardProps } from 'reka-ui'
+import { computed } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<ContextMenuSeparatorProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <ContextMenuSeparator :class="cn('-mx-1 my-1 h-px bg-muted', props.class)" v-bind="forwardedProps" />
+</template>

--- a/src/components/ui/context-menu/ContextMenuTrigger.vue
+++ b/src/components/ui/context-menu/ContextMenuTrigger.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { ContextMenuTriggerProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { ContextMenuTrigger, useForwardProps } from 'reka-ui'
+import { computed } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<ContextMenuTriggerProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <ContextMenuTrigger v-bind="forwardedProps" :class="cn('outline-none', props.class)">
+    <slot />
+  </ContextMenuTrigger>
+</template>

--- a/src/components/ui/context-menu/index.ts
+++ b/src/components/ui/context-menu/index.ts
@@ -1,0 +1,5 @@
+export { default as ContextMenu } from './ContextMenu.vue'
+export { default as ContextMenuTrigger } from './ContextMenuTrigger.vue'
+export { default as ContextMenuContent } from './ContextMenuContent.vue'
+export { default as ContextMenuItem } from './ContextMenuItem.vue'
+export { default as ContextMenuSeparator } from './ContextMenuSeparator.vue'

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -204,6 +204,38 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     )
   }
 
+  function duplicateTab(tabId: string): string | null {
+    const tab = tabsCollection.findOne({ id: tabId })
+    if (!tab)
+      return null
+
+    const newId = uuidv7()
+    const now = Date.now()
+
+    // Insert the duplicated tab
+    tabsCollection.insert({
+      ...tab,
+      id: newId,
+      title: `${tab.title} (Copy)`,
+      createdTime: now,
+      updatedTime: now,
+    })
+
+    // Update workspace's tabOrder to insert after the original tab
+    const workspace = workspacesCollection.findOne({ id: tab.workspaceId })
+    if (workspace) {
+      const originalIndex = workspace.tabOrder.indexOf(tabId)
+      const newOrder = [...workspace.tabOrder]
+      newOrder.splice(originalIndex + 1, 0, newId)
+      workspacesCollection.updateOne(
+        { id: tab.workspaceId },
+        { $set: { tabOrder: newOrder, updatedTime: now } },
+      )
+    }
+
+    return newId
+  }
+
   function deleteTab(tabId: string): void {
     const tab = tabsCollection.findOne({ id: tabId })
     if (!tab)
@@ -321,6 +353,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     createTab,
     updateTab,
     renameTab,
+    duplicateTab,
     deleteTab,
     setActiveTab,
     updateTabContent,


### PR DESCRIPTION
## Summary

Implements right-click context menu for sidebar tabs with rename, duplicate, and delete actions.

## Changes

- Added shadcn-vue context-menu components in `src/components/ui/context-menu/`
- Implemented `duplicateTab()` method in workspace store
- Integrated context menu into TabListItem component
- Added i18n translations for menu items (en-US and zh-CN)

Closes #5

---

Generated with [Claude Code](https://claude.ai/code)